### PR TITLE
Change S3 URL to be compatible with all regions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "servd/craft-remote-assets",
+    "name": "mwcbrent/craft-remote-assets",
     "description": "Move CP assets to an external filesystem such as S3",
     "type": "craft-plugin",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "keywords": [
         "craft",
         "cms",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mwcbrent/craft-remote-assets",
+    "name": "servd/craft-remote-assets",
     "description": "Move CP assets to an external filesystem such as S3",
     "type": "craft-plugin",
     "version": "0.1.8",
@@ -29,7 +29,7 @@
     },
     "autoload": {
         "psr-4": {
-          "mwcbrent\\craftremoteassets\\": "src/"
+          "servd\\craftremoteassets\\": "src/"
         }
     },
     "extra": {
@@ -38,6 +38,6 @@
         "hasCpSettings": false,
         "hasCpSection": false,
         "changelogUrl": "https://raw.githubusercontent.com/servdhost/craft-remote-assets/master/CHANGELOG.md",
-        "class": "mwcbrent\\craftremoteassets\\CraftRemoteAssets"
+        "class": "servd\\craftremoteassets\\CraftRemoteAssets"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,6 @@
         "hasCpSettings": false,
         "hasCpSection": false,
         "changelogUrl": "https://raw.githubusercontent.com/servdhost/craft-remote-assets/master/CHANGELOG.md",
-        "class": "servd\\craftremoteassets\\CraftRemoteAssets"
+        "class": "mwcbrent\\craftremoteassets\\CraftRemoteAssets"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "autoload": {
         "psr-4": {
-          "servd\\craftremoteassets\\": "src/"
+          "mwcbrent\\craftremoteassets\\": "src/"
         }
     },
     "extra": {

--- a/src/S3RemoteAssetStore.php
+++ b/src/S3RemoteAssetStore.php
@@ -51,8 +51,7 @@ class S3RemoteAssetStore
     public function getURLForKey($key)
     {
         $config = CraftRemoteAssets::getInstance()->getSettings()->s3Config;
-        return 'https://s3-' .
-            $config['region'] .
+        return 'https://s3' .
             '.amazonaws.com/' .
             $config['bucket'] . '/' .
             $config['root'] . '/' .


### PR DESCRIPTION
The S3 url used in `getURLForKey` isn't compatible with all regions (ex: us-east-1).  This URL pattern works more universally across the platform.